### PR TITLE
Fi client delets all relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ Response Code(s)
 | 201 | Relationship found and returned |
 | 404 | Relationship not found |
 
+#### View Relationships
+```
+GET           /relationships/getRelationships/service/:service/clientId/:clientId
+```
+
+Result
+```
+[
+  {
+    "arn": "AARN123",
+    "service": "service123",
+    "clientId": "clientId123",
+  },
+  {...}
+]
+```
+
+Response Code(s)
+
+| Status Code | Description |
+|---|---|
+| 201 | Relationship found and returned |
+| 404 | Relationship not found |
+
 #### Delete Relationship
 ```
 DELETE   	/agent-fi-relationship/relationships/agent/:arn/service/:service/client/:clientId
@@ -62,6 +86,17 @@ Response Code(s)
 | Status Code | Description |
 |---|---|
 | 200 | Relationship deleted |
+
+#### Delete Relationships
+```
+DELETE   	DELETE        /relationships/de-auth-agents/service/:service/clientId/:clientId
+```
+
+Response Code(s)
+
+| Status Code | Description |
+|---|---|
+| 200 | Relationships deleted |
 
 #### Access Control - View Relationship for Afi
 ```

--- a/app/uk/gov/hmrc/agentfirelationship/connectors/AgentClientAuthConnector.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/connectors/AgentClientAuthConnector.scala
@@ -36,6 +36,7 @@ import scala.concurrent.Future
 @Singleton
 class AgentClientAuthConnector @Inject() extends AuthorisedFunctions {
   implicit def hc(implicit rh: RequestHeader) = fromHeadersAndSession(rh.headers)
+
   override def authConnector: AuthConnector = MicroserviceAuthConnector
 
   private type AfiAction = Request[AnyContent] => TaxIdentifier => Future[Result]
@@ -62,7 +63,6 @@ class AgentClientAuthConnector @Inject() extends AuthorisedFunctions {
           Logger.warn("Authorisation exception whilst trying to manipulate relationships", ex)
           Future.successful(Forbidden)
       }
-
   }
 
   private def extractArn(enrolls: Set[Enrolment]): Option[Arn] =
@@ -72,5 +72,4 @@ class AgentClientAuthConnector @Inject() extends AuthorisedFunctions {
   private def extractNino(enrolls: Set[Enrolment]): Option[Nino] = {
     enrolls.find(_.key == "HMRC-NI").flatMap(_.getIdentifier("NINO")).map(x => Nino(x.value))
   }
-
 }

--- a/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
@@ -44,6 +44,7 @@ class RelationshipController @Inject()(authAuditConnector: AuthAuditConnector,
                                        @Named("features.copy-cesa-relationships") copyCesaRelationships: Boolean)
 extends BaseController {
 
+
   def findClientRelationships(service: String, clientId: String): Action[AnyContent] = Action.async { implicit request =>
     mongoService.findClientRelationships(service, clientId) map { result =>
       if (result.nonEmpty) Ok(toJson(result)) else NotFound

--- a/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
@@ -43,8 +43,6 @@ class RelationshipController @Inject()(authAuditConnector: AuthAuditConnector,
                                        authConnector: AgentClientAuthConnector,
                                        @Named("features.copy-cesa-relationships") copyCesaRelationships: Boolean)
 extends BaseController {
-
-
   def findClientRelationships(service: String, clientId: String): Action[AnyContent] = Action.async { implicit request =>
     mongoService.findClientRelationships(service, clientId) map { result =>
       if (result.nonEmpty) Ok(toJson(result)) else NotFound

--- a/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
@@ -42,6 +42,17 @@ class RelationshipController @Inject()(authAuditConnector: AuthAuditConnector,
                                        @Named("features.copy-cesa-relationships") copyCesaRelationships: Boolean)
 extends BaseController {
 
+  def findClientRelationships(service: String, clientId: String): Action[AnyContent] = Action.async { implicit request =>
+    mongoService.findClientRelationshipsQuery(service, clientId) map { result =>
+      if (result.nonEmpty) Ok(toJson(result)) else NotFound
+    }
+  }
+
+  def deleteClientRelationships(service: String, clientId: String): Action[AnyContent] = Action.async { implicit request =>
+    val relationshipsDelted: Future[Boolean] = mongoService.deleteRelationships(service, clientId)
+    relationshipsDelted.map(if (_) Ok else NotFound)
+  }
+
   def findRelationship(arn: String, service: String, clientId: String): Action[AnyContent] = Action.async { implicit request =>
     mongoService.findRelationships(arn, service, clientId) map { result =>
       if (result.nonEmpty) {
@@ -71,7 +82,6 @@ extends BaseController {
               Logger.info("Relationship already exists")
               Future successful Created
           }
-
         }
     }
 
@@ -85,7 +95,6 @@ extends BaseController {
             _ <- auditService.sendDeleteRelationshipEvent(auditData)
           } yield successOrFail
           relationshipDeleted.map(if (_) Ok else NotFound)
-
         }
   }
 

--- a/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
@@ -44,7 +44,6 @@ class RelationshipController @Inject()(authAuditConnector: AuthAuditConnector,
                                        @Named("features.copy-cesa-relationships") copyCesaRelationships: Boolean)
 extends BaseController {
 
-
   def findClientRelationships(service: String, clientId: String): Action[AnyContent] = Action.async { implicit request =>
     mongoService.findClientRelationships(service, clientId) map { result =>
       if (result.nonEmpty) Ok(toJson(result)) else NotFound

--- a/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
@@ -24,6 +24,7 @@ import play.api.libs.json.Format
 import play.api.libs.json.Json.{format, toJsFieldJsValueWrapper}
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.bson.BSONDocument
+import reactivemongo.play.json.collection.JSONCollection
 import uk.gov.hmrc.agentfirelationship.models.Relationship
 import uk.gov.hmrc.mongo.ReactiveRepository
 
@@ -34,22 +35,38 @@ class RelationshipMongoService @Inject()(mongoComponent: ReactiveMongoComponent)
   extends ReactiveRepository[Relationship, String]("fi-relationship", mongoComponent.mongoConnector.db, format[Relationship], implicitly[Format[String]]) {
 
   def findRelationships(arn: String, service: String, clientId: String)(implicit ec: ExecutionContext): Future[List[Relationship]] = {
-      find(Seq(
-        "arn" -> arn,
-        "service" -> service,
-        "clientId" -> clientId)
-        .map(option => option._1 -> toJsFieldJsValueWrapper(option._2)): _*)
+    find(Seq(
+      "arn" -> arn,
+      "service" -> service,
+      "clientId" -> clientId)
+      .map(option => option._1 -> toJsFieldJsValueWrapper(option._2)): _*)
+  }
+
+  def findClientRelationshipsQuery(service: String, clientId: String)(implicit ec: ExecutionContext): Future[List[Relationship]] = {
+    find(Seq(
+      "service" -> service,
+      "clientId" -> clientId)
+      .map(option => option._1 -> toJsFieldJsValueWrapper(option._2)): _*)
   }
 
   def createRelationship(relationship: Relationship)(implicit ec: ExecutionContext): Future[Unit] = {
-      insert(relationship).map(_ => ())
+    insert(relationship).map(_ => ())
   }
 
   def deleteRelationship(arn: String, service: String, clientId: String)(implicit ec: ExecutionContext): Future[Boolean] = {
-      remove(
-        "arn" -> arn,
-        "service" -> service,
-        "clientId" -> clientId)
-        .map(result => if (result.n == 0) false else result.ok)
+    remove(
+      "arn" -> arn,
+      "service" -> service,
+      "clientId" -> clientId)
+      .map(result => if (result.n == 0) false else result.ok)
   }
+
+  def deleteRelationships(service: String, clientId: String)(implicit ec: ExecutionContext): Future[Boolean] = {
+    remove(
+      "service" -> service,
+      "clientId" -> clientId)
+      .map(result => if (result.n == 0) false else result.ok)
+  }
+
+
 }

--- a/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
@@ -67,4 +67,6 @@ class RelationshipMongoService @Inject()(mongoComponent: ReactiveMongoComponent)
       "clientId" -> clientId)
       .map(result => if (result.n == 0) false else result.ok)
   }
+
+
 }

--- a/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
@@ -67,6 +67,4 @@ class RelationshipMongoService @Inject()(mongoComponent: ReactiveMongoComponent)
       "clientId" -> clientId)
       .map(result => if (result.n == 0) false else result.ok)
   }
-
-
 }

--- a/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
@@ -42,7 +42,7 @@ class RelationshipMongoService @Inject()(mongoComponent: ReactiveMongoComponent)
       .map(option => option._1 -> toJsFieldJsValueWrapper(option._2)): _*)
   }
 
-  def findClientRelationshipsQuery(service: String, clientId: String)(implicit ec: ExecutionContext): Future[List[Relationship]] = {
+  def findClientRelationships(service: String, clientId: String)(implicit ec: ExecutionContext): Future[List[Relationship]] = {
     find(Seq(
       "service" -> service,
       "clientId" -> clientId)
@@ -67,6 +67,4 @@ class RelationshipMongoService @Inject()(mongoComponent: ReactiveMongoComponent)
       "clientId" -> clientId)
       .map(result => if (result.n == 0) false else result.ok)
   }
-
-
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,6 +1,9 @@
 # microservice specific routes
 
 
+GET           /relationships/getRelationships/service/:service/clientId/:clientId                     @uk.gov.hmrc.agentfirelationship.controllers.RelationshipController.findClientRelationships(service: String, clientId: String)
+DELETE        /relationships/de-auth-agents/service/:service/clientId/:clientId                       @uk.gov.hmrc.agentfirelationship.controllers.RelationshipController.deleteClientRelationships(service: String,clientId: String)
+
 GET           /relationships/agent/:arn/service/:service/client/:clientId                             @uk.gov.hmrc.agentfirelationship.controllers.RelationshipController.findRelationship(arn: String, service: String, clientId: String)
 PUT           /relationships/agent/:arn/service/:service/client/:clientId/startDate/:startDate        @uk.gov.hmrc.agentfirelationship.controllers.RelationshipController.createRelationship(arn: String, service: String, clientId: String, startDate: String)
 DELETE        /relationships/agent/:arn/service/:service/client/:clientId                             @uk.gov.hmrc.agentfirelationship.controllers.RelationshipController.deleteRelationship(arn: String, service: String, clientId: String)

--- a/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
@@ -192,11 +192,12 @@ class RelationshipControllerSpec extends UnitSpec with MockitoSugar with GuiceOn
     }
 
     "return Status: OK for deleting multiple records as a client" in {
-      authStub(clientAffinityAndEnrolments)
-      when(mockMongoService.findClientRelationships(eqs(testService), eqs(validTestNINO))(any()))
-        .thenReturn(Future successful List(validTestRelationship,validTestRelationship))
+
+      when(mockMongoService.findClientRelationships(eqs(testService), eqs(validTestNINO))(any())).thenReturn(Future successful List(validTestRelationship,validTestRelationship))
       when(mockMongoService.deleteRelationships(eqs(testService), eqs(validTestNINO))(any()))
         .thenReturn(Future successful true)
+      when(mockAuthAuditConnector.userDetails(any(), any())).thenReturn(Future successful UserDetails(testCredId))
+      when(mockAuditService.sendDeleteRelationshipEvent(any())(any(), any())).thenReturn(Future successful())
 
       val response = controller.deleteClientRelationships(testService, validTestNINO)(fakeRequest)
 

--- a/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
@@ -238,7 +238,8 @@ class RelationshipControllerSpec extends UnitSpec with MockitoSugar with GuiceOn
         .thenReturn(Future successful false)
       when(mockAuthAuditConnector.userDetails(any(), any())).thenReturn(Future successful UserDetails(testCredId))
       when(mockAuditService.sendDeleteRelationshipEvent(any())(any(), any())).thenReturn(Future successful())
-      when(mockMongoService.findClientRelationships(eqs(testService), eqs(validTestNINO))(any())).
+      when(mockMongoService.findClientRelationships(any[String], any[String])(any[ExecutionContext])).
+        thenReturn(Future successful List.empty)
 
       val response = controller.deleteClientRelationships(testService, validTestNINO)(fakeRequest)
 

--- a/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
@@ -40,14 +40,16 @@ class RelationshipControllerSpec extends UnitSpec with MockitoSugar with GuiceOn
     override def authConnector: AuthConnector = mockPlayAuthConnector
   }
 
-  val controller = new RelationshipController(mockAuthAuditConnector, mockAuditService, mockMongoService, mockAgentClientAuthConnector, false)
+  val controller = new RelationshipController(mockAuthAuditConnector, mockAuditService,
+    mockMongoService, mockAgentClientAuthConnector, false)
 
   override def afterEach() {
     reset(mockMongoService, mockAuditService, mockPlayAuthConnector)
   }
 
   private def authStub(returnValue: Future[~[Option[AffinityGroup], Enrolments]]) =
-    when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup], Enrolments]]]())(any(), any())).thenReturn(returnValue)
+    when(mockPlayAuthConnector.authorise(any(), any[Retrieval[~[Option[AffinityGroup],
+      Enrolments]]]())(any(), any())).thenReturn(returnValue)
 
   "RelationshipController" should {
     "return Status: OK when successfully finding relationship" in {
@@ -191,11 +193,10 @@ class RelationshipControllerSpec extends UnitSpec with MockitoSugar with GuiceOn
 
     "return Status: OK for deleting multiple records as a client" in {
       authStub(clientAffinityAndEnrolments)
-      when(mockMongoService.findClientRelationships(eqs(testService), eqs(validTestNINO))(any())).thenReturn(Future successful List(validTestRelationship,validTestRelationship))
+      when(mockMongoService.findClientRelationships(eqs(testService), eqs(validTestNINO))(any()))
+        .thenReturn(Future successful List(validTestRelationship,validTestRelationship))
       when(mockMongoService.deleteRelationships(eqs(testService), eqs(validTestNINO))(any()))
         .thenReturn(Future successful true)
-      when(mockAuthAuditConnector.userDetails(any(), any())).thenReturn(Future successful UserDetails(testCredId))
-      when(mockAuditService.sendDeleteRelationshipEvent(any())(any(), any())).thenReturn(Future successful())
 
       val response = controller.deleteClientRelationships(testService, validTestNINO)(fakeRequest)
 
@@ -236,7 +237,8 @@ class RelationshipControllerSpec extends UnitSpec with MockitoSugar with GuiceOn
         .thenReturn(Future successful false)
       when(mockAuthAuditConnector.userDetails(any(), any())).thenReturn(Future successful UserDetails(testCredId))
       when(mockAuditService.sendDeleteRelationshipEvent(any())(any(), any())).thenReturn(Future successful())
-      when(mockMongoService.findClientRelationships(any[String], any[String])(any[ExecutionContext])).thenReturn(Future successful List.empty)
+      when(mockMongoService.findClientRelationships(eqs(testService), eqs(validTestNINO))(any())).
+        thenReturn(Future successful List(validTestRelationship,validTestRelationship))
 
       val response = controller.deleteClientRelationships(testService, validTestNINO)(fakeRequest)
 
@@ -268,7 +270,6 @@ class RelationshipControllerSpec extends UnitSpec with MockitoSugar with GuiceOn
 
     "return Status: FORBIDDEN when logged in Client NINO does not match given NINO when deleting relationships" in {
       authStub(clientAffinityAndEnrolments)
-
       val response = controller.deleteClientRelationships(testService, "AB123456C")(fakeRequest)
 
       status(response) shouldBe FORBIDDEN

--- a/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
@@ -191,15 +191,15 @@ class RelationshipControllerSpec extends UnitSpec with MockitoSugar with GuiceOn
 
     "return Status: OK for deleting a record as a client" in {
       authStub(clientAffinityAndEnrolments)
-      when(mockMongoService.deleteRelationship(eqs(validTestArn), eqs(testService), eqs(validTestNINO))(any()))
+      when(mockMongoService.deleteRelationships(eqs(testService), eqs(validTestNINO))(any()))
         .thenReturn(Future successful true)
-      when(mockAuthAuditConnector.userDetails(any(), any())).thenReturn(Future successful UserDetails(testCredId))
-      when(mockAuditService.sendDeleteRelationshipEvent(any())(any(), any())).thenReturn(Future successful())
+      //when(mockAuthAuditConnector.userDetails(any(), any())).thenReturn(Future successful UserDetails(testCredId))
+      //when(mockAuditService.sendDeleteRelationshipEvent(any())(any(), any())).thenReturn(Future successful())
 
-      val response = controller.deleteRelationship(validTestArn, testService, validTestNINO)(fakeRequest)
+      val response = controller.deleteClientRelationships(testService, validTestNINO)(fakeRequest)
 
       status(response) shouldBe OK
-      verify(mockMongoService, times(1)).deleteRelationship(any(), any(), any())(any())
+      verify(mockMongoService, times(1)).deleteRelationships(any(), any())(any())
     }
 
     "return Status: OK for deleting a record as an agent" in {
@@ -230,15 +230,15 @@ class RelationshipControllerSpec extends UnitSpec with MockitoSugar with GuiceOn
 
     "return Status: NOT_FOUND for failing to delete a record as a client" in {
       authStub(clientAffinityAndEnrolments)
-      when(mockMongoService.deleteRelationship(any(), any(), any())(any()))
+      when(mockMongoService.deleteRelationships(any(), any())(any()))
         .thenReturn(Future successful false)
-      when(mockAuthAuditConnector.userDetails(any(), any())).thenReturn(Future successful UserDetails(testCredId))
-      when(mockAuditService.sendDeleteRelationshipEvent(any())(any(), any())).thenReturn(Future successful())
+      //when(mockAuthAuditConnector.userDetails(any(), any())).thenReturn(Future successful UserDetails(testCredId))
+      //when(mockAuditService.sendDeleteRelationshipEvent(any())(any(), any())).thenReturn(Future successful())
 
-      val response = controller.deleteRelationship(validTestArn, testService, validTestNINO)(fakeRequest)
+      val response = controller.deleteClientRelationships(testService, validTestNINO)(fakeRequest)
 
       status(response) shouldBe NOT_FOUND
-      verify(mockMongoService, times(1)).deleteRelationship(any(), any(), any())(any())
+      verify(mockMongoService, times(1)).deleteRelationships(any(), any())(any())
     }
 
     "return Status: NOT_FOUND for failing to delete a record as an agent" in {
@@ -266,10 +266,10 @@ class RelationshipControllerSpec extends UnitSpec with MockitoSugar with GuiceOn
     "return Status: FORBIDDEN when logged in Client NINO does not match given NINO when deleting relationship" in {
       authStub(clientAffinityAndEnrolments)
 
-      val response = controller.deleteRelationship(validTestArn, testService, "AB123456C")(fakeRequest)
+      val response = controller.deleteClientRelationships(testService, "AB123456C")(fakeRequest)
 
       status(response) shouldBe FORBIDDEN
-      verify(mockMongoService, times(0)).deleteRelationship(any(), any(), any())(any())
+      verify(mockMongoService, times(0)).deleteRelationships(any(), any())(any())
     }
 
     "return Status: OK for finding data via access control endpoint" in {


### PR DESCRIPTION
added funcioanlity that does not use arn to delete all relationships for given nino and service name("afi")
added tests and adjusted the audit
readme.md updated

requires squashing commits