### PR TITLE
APB-1831 - Move from java.time to joda to be consistent with ITSA code

### DIFF
--- a/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.agentfirelationship.controllers
 
-import java.time.{LocalDateTime, ZoneId}
 import javax.inject.{Inject, Named, Singleton}
 
 import org.joda.time.DateTime
@@ -69,7 +68,7 @@ class RelationshipController @Inject()(authAuditConnector: AuthAuditConnector,
                       service = service,
                       clientId = clientId,
                       relationshipStatus = RelationshipStatus.Active,
-                      startDate = LocalDateTime.now(ZoneId.of("UTC")),
+                      startDate = DateTime.now,
                       endDate = None,
                       fromCesa = Some(true))
 
@@ -100,7 +99,7 @@ class RelationshipController @Inject()(authAuditConnector: AuthAuditConnector,
     }
   }
 
-  case class Invitation(startDate: LocalDateTime)
+  case class Invitation(startDate: DateTime)
   implicit val invitationFormat = Json.format[Invitation]
 
   def createRelationship(arn: String, service: String, clientId: String) = Action.async(parse.json) { implicit request =>

--- a/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
@@ -18,9 +18,9 @@ package uk.gov.hmrc.agentfirelationship.controllers
 
 import javax.inject.{Inject, Named, Singleton}
 
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json.Json
 import play.api.libs.json.Json.toJson
 import play.api.mvc._
 import uk.gov.hmrc.agentfirelationship.audit.{AuditData, AuditService}
@@ -68,7 +68,7 @@ class RelationshipController @Inject()(authAuditConnector: AuthAuditConnector,
                       service = service,
                       clientId = clientId,
                       relationshipStatus = RelationshipStatus.Active,
-                      startDate = DateTime.now,
+                      startDate = DateTime.now(DateTimeZone.UTC),
                       endDate = None,
                       fromCesa = Some(true))
 

--- a/app/uk/gov/hmrc/agentfirelationship/models/Relationship.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/models/Relationship.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.agentfirelationship.models
 
-import java.time.LocalDateTime
-
+import org.joda.time.DateTime
 import play.api.libs.json.Json
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 
@@ -25,8 +24,8 @@ case class Relationship(arn: Arn,
                         service: String,
                         clientId: String,
                         relationshipStatus: RelationshipStatus,
-                        startDate: LocalDateTime,
-                        endDate: Option[LocalDateTime],
+                        startDate: DateTime,
+                        endDate: Option[DateTime],
                         fromCesa: Option[Boolean] = Some(false))
 
 object Relationship {

--- a/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
@@ -16,11 +16,12 @@
 
 package uk.gov.hmrc.agentfirelationship.services
 
-import java.time.{LocalDateTime, ZoneId}
 import javax.inject.Inject
 
 import com.google.inject.Singleton
+import org.joda.time.DateTime
 import play.api.Logger
+import play.api.libs.json.{Json, Writes}
 import play.api.libs.json.Json.toJsFieldJsValueWrapper
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.bson.{BSONDocument, BSONObjectID}
@@ -75,7 +76,7 @@ class RelationshipMongoService @Inject()(mongoComponent: ReactiveMongoComponent)
     collection.update(
       selector,
       BSONDocument("$set" -> BSONDocument("relationshipStatus" -> RelationshipStatus.Terminated.key,
-        "endDate" -> LocalDateTime.now(ZoneId.of("UTC")).toString)),
+        "endDate" -> Json.toJson(DateTime.now))),
       multi = multi
     ).map { result =>
       result.writeErrors.foreach(error => Logger.warn(s"Updating Relationship status to TERMINATED for ${selector.elements.mkString} failed: $error"))

--- a/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
@@ -19,9 +19,9 @@ package uk.gov.hmrc.agentfirelationship.services
 import javax.inject.Inject
 
 import com.google.inject.Singleton
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{Json}
 import play.api.libs.json.Json.toJsFieldJsValueWrapper
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.bson.{BSONDocument, BSONObjectID}
@@ -76,7 +76,7 @@ class RelationshipMongoService @Inject()(mongoComponent: ReactiveMongoComponent)
     collection.update(
       selector,
       BSONDocument("$set" -> BSONDocument("relationshipStatus" -> RelationshipStatus.Terminated.key,
-        "endDate" -> Json.toJson(DateTime.now))),
+        "endDate" -> Json.toJson(DateTime.now(DateTimeZone.UTC)))),
       multi = multi
     ).map { result =>
       result.writeErrors.foreach(error => Logger.warn(s"Updating Relationship status to TERMINATED for ${selector.elements.mkString} failed: $error"))

--- a/it/uk/gov/hmrc/agentfirelationship/CreateRelationshipIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/CreateRelationshipIntegrationSpec.scala
@@ -1,8 +1,8 @@
 package uk.gov.hmrc.agentfirelationship
 
-import java.time.LocalDateTime
 import javax.inject.Singleton
 
+import org.joda.time.DateTime
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -28,7 +28,7 @@ class CreateRelationshipIntegrationSpec extends IntegrationSpec with UpstreamSer
   override def arn = agentId
   override def nino = clientId
 
-  val testResponseDate = LocalDateTime.now
+  val testResponseDate = DateTime.now
   val validTestRelationship: Relationship = Relationship(Arn(arn), service, nino, Active, testResponseDate, None)
 
   protected def appBuilder: GuiceApplicationBuilder =

--- a/it/uk/gov/hmrc/agentfirelationship/TerminateRelationshipIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/TerminateRelationshipIntegrationSpec.scala
@@ -1,8 +1,8 @@
 package uk.gov.hmrc.agentfirelationship
 
-import java.time.LocalDateTime
 import javax.inject.Singleton
 
+import org.joda.time.DateTime
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -15,7 +15,6 @@ import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-
 import scala.concurrent.{Await, Future}
 
 @Singleton
@@ -29,7 +28,7 @@ class TerminateRelationshipIntegrationSpec extends IntegrationSpec with Upstream
   override def arn = agentId
   override def nino = clientId
 
-  val testResponseDate = LocalDateTime.now
+  val testResponseDate = DateTime.now
   val validTestRelationship: Relationship = Relationship(Arn(arn), service, nino, Active, testResponseDate, None)
 
   protected def appBuilder: GuiceApplicationBuilder =

--- a/it/uk/gov/hmrc/agentfirelationship/package.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/package.scala
@@ -1,6 +1,6 @@
 package uk.gov.hmrc
 
-import java.time.LocalDateTime
+import org.joda.time.DateTime
 
 package object agentfirelationship {
   val fakeCredId = "fakeCredId"
@@ -9,5 +9,5 @@ package object agentfirelationship {
   val clientId = "AE123456C"
   val service = "afi"
   val auditDetails = Map("authProviderId" -> fakeCredId, "arn" -> agentId, "regime" -> "afi", "regimeId" -> clientId)
-  val testResponseDate = LocalDateTime.now
+  val testResponseDate = DateTime.now
 }

--- a/it/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoServiceIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoServiceIntegrationSpec.scala
@@ -1,8 +1,8 @@
 package uk.gov.hmrc.agentfirelationship.services
 
-import java.time.LocalDateTime
 import javax.inject.Singleton
 
+import org.joda.time.DateTime
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -12,6 +12,7 @@ import uk.gov.hmrc.agentfirelationship.{agentId, clientId, service}
 import uk.gov.hmrc.agentfirelationship.support._
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.play.test.UnitSpec
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @Singleton
@@ -25,10 +26,10 @@ class RelationshipMongoServiceIntegrationSpec extends UnitSpec
   override def arn = agentId
   override def nino = clientId
 
-  val testResponseDate: String = LocalDateTime.now.toString
-  val validTestRelationship: Relationship = Relationship(Arn(arn), service, nino, Active, LocalDateTime.parse(testResponseDate), None)
+  val testResponseDate = DateTime.now
+  val validTestRelationship: Relationship = Relationship(Arn(arn), service, nino, Active, testResponseDate, None)
   val invalidTestRelationship: Relationship = validTestRelationship.copy(relationshipStatus = Terminated)
-  val validTestRelationshipCesa: Relationship = Relationship(Arn(arn), service, nino, Active, LocalDateTime.parse(testResponseDate), None, fromCesa = Some(true))
+  val validTestRelationshipCesa: Relationship = Relationship(Arn(arn), service, nino, Active, testResponseDate, None, fromCesa = Some(true))
 
   protected def appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()

--- a/it/uk/gov/hmrc/agentfirelationship/support/RelationshipActions.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/support/RelationshipActions.scala
@@ -1,7 +1,6 @@
 package uk.gov.hmrc.agentfirelationship.support
 
-import java.time.LocalDateTime
-
+import org.joda.time.DateTime
 import org.scalatest.Suite
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.play.ServerProvider
@@ -18,7 +17,7 @@ trait RelationshipActions extends ScalaFutures {
 
   val wsClient: WSClient = app.injector.instanceOf[WSClient]
 
-  def createRelationship(agentId: String, clientId: String, service: String, startDate: LocalDateTime): Future[WSResponse] =
+  def createRelationship(agentId: String, clientId: String, service: String, startDate: DateTime): Future[WSResponse] =
     wsClient
       .url(s"$url/agent/$agentId/service/$service/client/$clientId")
       .put(Json.obj("startDate"-> startDate))

--- a/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.agentfirelationship.controllers
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import org.mockito.ArgumentMatchers.{any, eq => eqs}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.BeforeAndAfterEach

--- a/test/uk/gov/hmrc/agentfirelationship/controllers/package.scala
+++ b/test/uk/gov/hmrc/agentfirelationship/controllers/package.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.agentfirelationship
 
-import java.time.LocalDateTime
-
+import org.joda.time.DateTime
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.FakeRequest
 import play.mvc.Http.HeaderNames
@@ -33,7 +32,7 @@ import scala.concurrent.Future
 
 package object controllers {
   implicit val hc = new HeaderCarrier
-  val testResponseDate = LocalDateTime.now
+  val testResponseDate = DateTime.now
 
   val fakeRequest = FakeRequest("GET", "")
 


### PR DESCRIPTION
As we a serialising/de-serialising thought it best to use a consistent type across codebases and use default serialisation for the type