### PR TITLE
Revert "[APB-1831][OP] Move from java.time to joda to be consistent w…

### DIFF
--- a/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/controllers/RelationshipController.scala
@@ -16,11 +16,12 @@
 
 package uk.gov.hmrc.agentfirelationship.controllers
 
+import java.time.{LocalDateTime, ZoneId}
 import javax.inject.{Inject, Named, Singleton}
 
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.DateTime
 import play.api.Logger
-import play.api.libs.json.Json
+import play.api.libs.json.{Format, Json}
 import play.api.libs.json.Json.toJson
 import play.api.mvc._
 import uk.gov.hmrc.agentfirelationship.audit.{AuditData, AuditService}
@@ -68,7 +69,7 @@ class RelationshipController @Inject()(authAuditConnector: AuthAuditConnector,
                       service = service,
                       clientId = clientId,
                       relationshipStatus = Some(RelationshipStatus.Active),
-                      startDate = DateTime.now(DateTimeZone.UTC),
+                      startDate = LocalDateTime.now(ZoneId.of("UTC")),
                       endDate = None,
                       fromCesa = Some(true))
                     mongoService.createRelationship(activeRelationship)
@@ -98,7 +99,7 @@ class RelationshipController @Inject()(authAuditConnector: AuthAuditConnector,
     }
   }
 
-  case class Invitation(startDate: DateTime)
+  case class Invitation(startDate: LocalDateTime)
   implicit val invitationFormat = Json.format[Invitation]
 
   def createRelationship(arn: String, service: String, clientId: String) = Action.async(parse.json) { implicit request =>

--- a/app/uk/gov/hmrc/agentfirelationship/models/Relationship.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/models/Relationship.scala
@@ -16,7 +16,8 @@
 
 package uk.gov.hmrc.agentfirelationship.models
 
-import org.joda.time.DateTime
+import java.time.LocalDateTime
+
 import play.api.libs.json.Json
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 
@@ -24,8 +25,8 @@ case class Relationship(arn: Arn,
                         service: String,
                         clientId: String,
                         relationshipStatus: Option[RelationshipStatus] = Some(RelationshipStatus.Active),
-                        startDate: DateTime,
-                        endDate: Option[DateTime],
+                        startDate: LocalDateTime,
+                        endDate: Option[LocalDateTime],
                         fromCesa: Option[Boolean] = Some(false))
 
 object Relationship {

--- a/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
+++ b/app/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoService.scala
@@ -16,12 +16,11 @@
 
 package uk.gov.hmrc.agentfirelationship.services
 
+import java.time.{LocalDateTime, ZoneId}
 import javax.inject.Inject
 
 import com.google.inject.Singleton
-import org.joda.time.{DateTime, DateTimeZone}
 import play.api.Logger
-import play.api.libs.json.{Json}
 import play.api.libs.json.Json.toJsFieldJsValueWrapper
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.bson.{BSONDocument, BSONObjectID}
@@ -89,7 +88,7 @@ class RelationshipMongoService @Inject()(mongoComponent: ReactiveMongoComponent)
     collection.update(
       selector,
       BSONDocument("$set" -> BSONDocument("relationshipStatus" -> RelationshipStatus.Terminated.key,
-        "endDate" -> Json.toJson(DateTime.now(DateTimeZone.UTC)))),
+        "endDate" -> LocalDateTime.now(ZoneId.of("UTC")).toString)),
       multi = multi
     ).map { result =>
       result.writeErrors.foreach(error => Logger.warn(s"Updating Relationship status to TERMINATED for ${selector.elements.mkString} failed: $error"))

--- a/it/uk/gov/hmrc/agentfirelationship/CreateRelationshipIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/CreateRelationshipIntegrationSpec.scala
@@ -1,8 +1,8 @@
 package uk.gov.hmrc.agentfirelationship
 
+import java.time.LocalDateTime
 import javax.inject.Singleton
 
-import org.joda.time.DateTime
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -27,7 +27,8 @@ class CreateRelationshipIntegrationSpec extends IntegrationSpec with UpstreamSer
   override implicit lazy val app: Application = appBuilder.build()
   override def arn = agentId
   override def nino = clientId
-  val testResponseDate = DateTime.now
+
+  val testResponseDate = LocalDateTime.now
   val validTestRelationship: Relationship = Relationship(Arn(arn), service, nino, Some(Active), testResponseDate, None)
 
   protected def appBuilder: GuiceApplicationBuilder =

--- a/it/uk/gov/hmrc/agentfirelationship/TerminateRelationshipIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/TerminateRelationshipIntegrationSpec.scala
@@ -1,8 +1,8 @@
 package uk.gov.hmrc.agentfirelationship
 
+import java.time.LocalDateTime
 import javax.inject.Singleton
 
-import org.joda.time.DateTime
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -15,6 +15,7 @@ import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+
 import scala.concurrent.{Await, Future}
 
 @Singleton
@@ -27,8 +28,8 @@ class TerminateRelationshipIntegrationSpec extends IntegrationSpec with Upstream
   override implicit lazy val app: Application = appBuilder.build()
   override def arn = agentId
   override def nino = clientId
-  val testResponseDate = DateTime.now
 
+  val testResponseDate = LocalDateTime.now
   val validTestRelationship: Relationship = Relationship(Arn(arn), service, nino, Some(Active), testResponseDate, None)
 
   protected def appBuilder: GuiceApplicationBuilder =

--- a/it/uk/gov/hmrc/agentfirelationship/package.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/package.scala
@@ -1,6 +1,6 @@
 package uk.gov.hmrc
 
-import org.joda.time.DateTime
+import java.time.LocalDateTime
 
 package object agentfirelationship {
   val fakeCredId = "fakeCredId"
@@ -9,5 +9,5 @@ package object agentfirelationship {
   val clientId = "AE123456C"
   val service = "afi"
   val auditDetails = Map("authProviderId" -> fakeCredId, "arn" -> agentId, "regime" -> "afi", "regimeId" -> clientId)
-  val testResponseDate = DateTime.now
+  val testResponseDate = LocalDateTime.now
 }

--- a/it/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoServiceIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/services/RelationshipMongoServiceIntegrationSpec.scala
@@ -1,8 +1,8 @@
 package uk.gov.hmrc.agentfirelationship.services
 
+import java.time.LocalDateTime
 import javax.inject.Singleton
 
-import org.joda.time.DateTime
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -12,7 +12,6 @@ import uk.gov.hmrc.agentfirelationship.{agentId, clientId, service}
 import uk.gov.hmrc.agentfirelationship.support._
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.play.test.UnitSpec
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @Singleton
@@ -25,12 +24,11 @@ class RelationshipMongoServiceIntegrationSpec extends UnitSpec
   override implicit lazy val app: Application = appBuilder.build()
   override def arn = agentId
   override def nino = clientId
-  val testResponseDate = DateTime.now
 
-  val validTestRelationship: Relationship = Relationship(Arn(arn), service, nino, Some(Active), testResponseDate, None)
+  val testResponseDate: String = LocalDateTime.now.toString
+  val validTestRelationship: Relationship = Relationship(Arn(arn), service, nino, Some(Active), LocalDateTime.parse(testResponseDate), None)
   val invalidTestRelationship: Relationship = validTestRelationship.copy(relationshipStatus = Some(Terminated))
-  val validTestRelationshipCesa: Relationship = Relationship(Arn(arn), service, nino, Some(Active), testResponseDate, None, fromCesa = Some(true))
-
+  val validTestRelationshipCesa: Relationship = Relationship(Arn(arn), service, nino, Some(Active), LocalDateTime.parse(testResponseDate), None, fromCesa = Some(true))
 
   protected def appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()

--- a/it/uk/gov/hmrc/agentfirelationship/support/RelationshipActions.scala
+++ b/it/uk/gov/hmrc/agentfirelationship/support/RelationshipActions.scala
@@ -1,6 +1,7 @@
 package uk.gov.hmrc.agentfirelationship.support
 
-import org.joda.time.DateTime
+import java.time.LocalDateTime
+
 import org.scalatest.Suite
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.play.ServerProvider
@@ -17,7 +18,7 @@ trait RelationshipActions extends ScalaFutures {
 
   val wsClient: WSClient = app.injector.instanceOf[WSClient]
 
-  def createRelationship(agentId: String, clientId: String, service: String, startDate: DateTime): Future[WSResponse] =
+  def createRelationship(agentId: String, clientId: String, service: String, startDate: LocalDateTime): Future[WSResponse] =
     wsClient
       .url(s"$url/agent/$agentId/service/$service/client/$clientId")
       .put(Json.obj("startDate"-> startDate))

--- a/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentfirelationship/controllers/RelationshipControllerSpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.agentfirelationship.controllers
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import org.mockito.ArgumentMatchers.{any, eq => eqs}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.BeforeAndAfterEach

--- a/test/uk/gov/hmrc/agentfirelationship/controllers/package.scala
+++ b/test/uk/gov/hmrc/agentfirelationship/controllers/package.scala
@@ -16,7 +16,8 @@
 
 package uk.gov.hmrc.agentfirelationship
 
-import org.joda.time.DateTime
+import java.time.LocalDateTime
+
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.FakeRequest
 import play.mvc.Http.HeaderNames
@@ -32,6 +33,14 @@ import scala.concurrent.Future
 
 package object controllers {
   implicit val hc = new HeaderCarrier
+  val testResponseDate = LocalDateTime.now
+
+  val fakeRequest = FakeRequest("GET", "")
+
+  val fakeCreateRequest: FakeRequest[JsObject] = FakeRequest("PUT", "/")
+        .withHeaders(HeaderNames.CONTENT_TYPE -> "application/json")
+        .withBody(Json.obj("startDate" -> testResponseDate))
+
   val saAgentRef = SaAgentReference("T1113T")
   val saAgentRef2 = SaAgentReference("T1123T")
   val saAgentRef3 = SaAgentReference("T1133T")
@@ -39,15 +48,9 @@ package object controllers {
   val testCredId = "q213"
   val testService = "afi"
   val validTestNINO = "AE123456C"
-  val testResponseDate = DateTime.now
 
   val validTestRelationship: Relationship = Relationship(Arn(validTestArn), testService, validTestNINO, Some(Active), testResponseDate, None)
   val validTestRelationshipCesa: Relationship = Relationship(Arn(validTestArn), testService, validTestNINO, Some(Terminated), testResponseDate, None, fromCesa = Some(true))
-  val fakeRequest = FakeRequest("GET", "")
-  val fakeCreateRequest: FakeRequest[JsObject] = FakeRequest("PUT", "/")
-    .withHeaders(HeaderNames.CONTENT_TYPE -> "application/json")
-    .withBody(Json.obj("startDate" -> testResponseDate))
-
 
   val agentEnrolment = Set(
     Enrolment("HMRC-AS-AGENT", Seq(EnrolmentIdentifier("AgentReferenceNumber", validTestArn)),


### PR DESCRIPTION
…ith ITSA code"

This reverts commit cf51a39a27a1733d1296c5e25d2839e1a052478f.

Should fix bug relating to old data persisted using plays default java LocalDateTime serialiser    