### PR TITLE
[AO] keep `afi` endpoint while `agent-fi-access-control` is on

### DIFF
--- a/conf/app.routes
+++ b/conf/app.routes
@@ -7,5 +7,7 @@ DELETE        /relationships/agent/:arn/service/:service/client/:clientId       
 
 GET           /relationships/PERSONAL-INCOME-RECORD/agent/:arn/client/:clientId                       @uk.gov.hmrc.agentfirelationship.controllers.RelationshipController.findAfiRelationship(arn: String, clientId: String)
 
+GET           /relationships/afi/agent/:arn/client/:clientId                       @uk.gov.hmrc.agentfirelationship.controllers.RelationshipController.findAfiRelationship(arn: String, clientId: String)
+
 GET           /relationships/service/:service/clientId/:clientId                                      @uk.gov.hmrc.agentfirelationship.controllers.RelationshipController.findClientRelationships(service: String, clientId: String)
 DELETE        /relationships/service/:service/clientId/:clientId                                      @uk.gov.hmrc.agentfirelationship.controllers.RelationshipController.terminateClientRelationships(service: String,clientId: String)


### PR DESCRIPTION
The purpose of this PR is to keep `/agent-fi-relationship/relationships/afi/agent/:arn/client/:clientId` while `agent-fi-access-control` still serves authorisation requests from auth. After successful deployment of new `agent-access-control` together with new `auth` configuration we will be able to decommission POC access control and remove this endpoint.